### PR TITLE
Security module cleanup and deprecation fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def pyramid_config(db_engine):
         "sqlalchemy.url": DB_URL,
         "project_prefix": "tet",
         "pyramid.includes": ["pyramid_tm"],
-        "tet.security.authentication.secret": "secret",
+        "tet.security.authentication.secret": "test-jwt-secret-key-at-least-32-bytes",
     }
     with tetConfigurator() as config:
         config.add_settings(settings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import typing as tp
 import pytest
 from pyramid.request import Request
 from pyramid.response import Response
-from pyramid.security import Allow, Authenticated, Everyone, Deny
+from pyramid.authorization import Allow, Authenticated, Everyone, Deny
 from pyramid.testing import setUp, tearDown
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session

--- a/tests/models/accounts.py
+++ b/tests/models/accounts.py
@@ -3,7 +3,7 @@ from tet.sqlalchemy.password import UserPasswordMixin
 
 from sqlalchemy import Column, Integer, Text, Boolean, ForeignKey, UniqueConstraint
 from sqlalchemy import orm
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.schema import MetaData
 
 NAMING_CONVENTION = {

--- a/tests/services/security/test_authentication.py
+++ b/tests/services/security/test_authentication.py
@@ -231,7 +231,7 @@ def test_verify_jwt_returns_none_for_invalid_signature(token_service):
         "exp": datetime.now(timezone.utc) + timedelta(hours=1),
         "iat": datetime.now(timezone.utc),
     }
-    bad_token = pyjwt.encode(wrong_payload, "wrong-secret", algorithm="HS256")
+    bad_token = pyjwt.encode(wrong_payload, "wrong-secret-key-at-least-32-bytes!", algorithm="HS256")
     result = token_service.verify_jwt(bad_token)
     assert result is None
 

--- a/tet/security/policy.py
+++ b/tet/security/policy.py
@@ -4,7 +4,7 @@ from pyramid.authentication import CallbackAuthenticationPolicy
 from pyramid.authorization import ACLHelper
 from pyramid.interfaces import ISecurityPolicy
 from pyramid.request import Request
-from pyramid.security import Everyone, Authenticated
+from pyramid.authorization import Everyone, Authenticated
 from zope.interface import implementer
 
 

--- a/tet/sqlalchemy/password.py
+++ b/tet/sqlalchemy/password.py
@@ -1,6 +1,5 @@
 import sqlalchemy as sa
 from sqlalchemy import orm as orm
-from sqlalchemy.ext import declarative
 
 from ..util.crypt import crypt, verify
 
@@ -21,6 +20,6 @@ class UserPasswordMixin(object):
 
         return verify(password, self._password)
 
-    @declarative.declared_attr
+    @orm.declared_attr
     def password(cls):
         return orm.synonym("_password", descriptor=property(cls._get_password, cls._set_password))

--- a/tet/util/crypt.py
+++ b/tet/util/crypt.py
@@ -9,7 +9,7 @@ def crypt(password):
     else:
         password_8bit = password
 
-    rv = password_hash.encrypt(password_8bit)
+    rv = password_hash.hash(password_8bit)
     if not isinstance(rv, str):
         rv = rv.decode()
 


### PR DESCRIPTION
## Summary
- Move `json_body` parsing inside try blocks after auth checks (change_password, disable_mfa, revoke_tokens) so malformed requests still trigger audit events
- Add error handling to `mfa_verify` view
- Simplify `mfa_method_type.value` ternaries (enum values are always truthy)
- Fix deprecated imports: `pyramid.security` → `pyramid.authorization`, `sqlalchemy.ext.declarative` → `sqlalchemy.orm`
- Fix passlib deprecation: `.encrypt()` → `.hash()`
- Use RFC 7518-compliant HMAC key length in test secrets

## Test plan
- [x] All 100 tests pass
- [x] Warnings reduced from 81 → 40 (remaining are all third-party: webob, pkg_resources, cgi, crypt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)